### PR TITLE
Add create_thin classmethod to Partition

### DIFF
--- a/tests/golem/resources/test_partition.py
+++ b/tests/golem/resources/test_partition.py
@@ -102,3 +102,26 @@ def test_indexed_copy(temp_dir):
     for path_0, path_1 in zip(paths_0, paths_1):
         assert _sha256_file(path_0) == _sha256_file(path_1)
 
+def test_indexed_thin_copy(temp_dir):
+    sizes = [32145, 123, 1252336, 0, 412123, 213, 532390, 12]
+
+    paths_0 = _create_files(temp_dir, 'partition_0', sizes)
+    partition_0 = Partition(paths_0)
+
+    paths_1 = _create_paths(temp_dir, 'partition_1', len(sizes))
+    partition_1 = Partition.create_thin(paths_1, sizes)
+
+    partition_0.open()
+    partition_1.open()
+
+    try:
+        for i in range(partition_0.size()):
+            partition_1[i] = partition_0[i]
+    finally:
+
+        partition_0.close()
+        partition_1.close()
+
+    for path_0, path_1 in zip(paths_0, paths_1):
+        assert _sha256_file(path_0) == _sha256_file(path_1)
+


### PR DESCRIPTION
Add a `create_thin` classmethod that will allow creating partitions with specified file sizes and paths, but without allocating any disk space.

Also turn the `allocate` staticmethod into a classmethod for consistency.